### PR TITLE
Update fileio.py

### DIFF
--- a/fileio.py
+++ b/fileio.py
@@ -11,7 +11,7 @@ def read_conll_deps(f):
     sentences = []
 
     with open(f) as csvfile:
-        reader = csv.reader(csvfile, delimiter='\t')
+        reader = csv.reader(csvfile, delimiter='\t', quoting=csv.QUOTE_NONE)
 
         sentence = []
 


### PR DESCRIPTION
Ordinary quotation marks (") as found in the Universal Dependencies treebanks will throw the reader off track if quoting is not disabled.