### PR TITLE
chore: update to python3 compat

### DIFF
--- a/fx.py
+++ b/fx.py
@@ -7,7 +7,7 @@ LABEL = 3
 
 
 def head_children(arcs, h, sent):
-    children = filter(lambda x: x[0] == h, arcs)
+    children = list(filter(lambda x: x[0] == h, arcs))
     if len(children):
         lc1 = min(d for (h, d) in children)
         rc1 = max(d for (h, d) in children)

--- a/parse.py
+++ b/parse.py
@@ -196,7 +196,7 @@ class ArcEagerDepParser(GreedyDepParser):
         self.transition_funcs[ArcEagerDepParser.REDUCE] = ArcEagerDepParser.reduce
 
     def initial(self, sentence):
-        return Configuration(range(len(sentence)) + [len(sentence)], sentence)
+        return Configuration(list(range(len(sentence))) + [len(sentence)], sentence)
 
     def legal(self, conf):
         """
@@ -224,7 +224,7 @@ class ArcEagerDepParser(GreedyDepParser):
             s = conf.stack[-1]
 
             # if the s is already a dependent, we cannot left-arc
-            if len(filter(lambda hd: s == hd[1], conf.arcs)) > 0:
+            if len(list(filter(lambda hd: s == hd[1], conf.arcs))) > 0:
                 left_ok = False
             else:
                 reduce_ok = False
@@ -310,8 +310,8 @@ class ArcEagerDepParser(GreedyDepParser):
         b_deps = gold_conf.deps[b]
 
         # (b, k) and k in S
-        b_k_in_stack = filter(lambda dep: dep in conf.stack, b_deps)
-        b_k_final = filter(lambda dep: dep not in k_heads, b_k_in_stack)
+        b_k_in_stack = list(filter(lambda dep: dep in conf.stack, b_deps))
+        b_k_final = list(filter(lambda dep: dep not in k_heads, b_k_in_stack))
 
         # s is not gold head but real head (k) not in stack or buffer
         # and no gold deps of b in S -- (b, k) doesnt exist on stack
@@ -403,7 +403,7 @@ class ArcHybridDepParser(GreedyDepParser):
 
     def initial(self, sentence):
         self.root = len(sentence)
-        return Configuration(range(len(sentence)) + [len(sentence)], sentence)
+        return Configuration(list(range(len(sentence))) + [len(sentence)], sentence)
         # return Configuration([self.root] + range(len(sentence)), sentence)
 
     def legal(self, conf):
@@ -485,7 +485,7 @@ class ArcHybridDepParser(GreedyDepParser):
         # Cost is the number of arcs in T of the form (s0, d) and (h, s0) for h in H and d in D
         if b in gold_conf.heads and gold_conf.heads[b] in conf.stack[0:-1]:
             return False
-        ll = len(filter(lambda dep: dep in conf.stack, gold_conf.deps[b]))
+        ll = len(list(filter(lambda dep: dep in conf.stack, gold_conf.deps[b])))
         return ll == 0
 
     @staticmethod


### PR DESCRIPTION
This PR updates the code to work on python3 as well as python2. To avoid a dependence on six I just wrap the filters in a `list` call. This means that the result is list in both 2/3. Without these changes things like the `len(filter(...` crash on python3 because filter is now an iterator instead of returning a list.