### PR TITLE
fix: zero cost left method of arc hybrid

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -458,7 +458,7 @@ class ArcHybridDepParser(GreedyDepParser):
         s0 = conf.stack[-1]
         s1 = len(conf.stack) > 2 and conf.stack[-2] or None
 
-        if gold_conf.deps[s0] in conf.buffer:
+        if any(dep in conf.buffer for dep in gold_conf.deps[s0]):
             return False
 
         H = conf.buffer[1:] + [s1]


### PR DESCRIPTION
This PR fixes a bug in the zero cost left oracle of the hybrid parser. A word can have multiple dependents so in this case `gold_conf.deps[s0]` is a list so it would never been in the buffer, instead you need to check if any of the dependents in the list are in the buffer. This means that there are situations where a left action would not be zero cost but the says it is.

Running the old version of the code 5 times I got an accuracy of  `82.25 ± 0.41` while with this patch we see a slight performance boost. `83.28 ± 0.16`